### PR TITLE
Add contentTypes to first and third party objects

### DIFF
--- a/lib/collect.js
+++ b/lib/collect.js
@@ -102,6 +102,42 @@ module.exports = {
    * @private
    */
   contentType: (asset, myPage) => {
+    if (myPage.contentTypes === {}) {
+      // we have a couple of default content types that we always reports
+      // if we find others, just add them
+      myPage.contentTypes = {
+        html: {
+          transferSize: 0,
+          contentSize: 0,
+          headerSize: 0,
+          requests: 0,
+        },
+        css: {
+          transferSize: 0,
+          contentSize: 0,
+          headerSize: 0,
+          requests: 0,
+        },
+        javascript: {
+          transferSize: 0,
+          contentSize: 0,
+          headerSize: 0,
+          requests: 0,
+        },
+        image: {
+          transferSize: 0,
+          contentSize: 0,
+          headerSize: 0,
+          requests: 0,
+        },
+        font: {
+          transferSize: 0,
+          contentSize: 0,
+          headerSize: 0,
+          requests: 0,
+        },
+      };
+    }
     if (asset.status === 200) {
       // TODO how to handle unknown?
       if (myPage.contentTypes[asset.type]) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,47 +42,16 @@ module.exports = {
           // TODO this will not be right if redirected!!!
           httpType: util.getConnectionType(har.log.entries[0].response.httpVersion),
           httpVersion: util.getHTTPVersion(har.log.entries[0].response.httpVersion),
-          // we have a couple of default content types that we always reports
-          // if we find others, just add them
-          contentTypes: {
-            html: {
-              transferSize: 0,
-              contentSize: 0,
-              headerSize: 0,
-              requests: 0,
-            },
-            css: {
-              transferSize: 0,
-              contentSize: 0,
-              headerSize: 0,
-              requests: 0,
-            },
-            javascript: {
-              transferSize: 0,
-              contentSize: 0,
-              headerSize: 0,
-              requests: 0,
-            },
-            image: {
-              transferSize: 0,
-              contentSize: 0,
-              headerSize: 0,
-              requests: 0,
-            },
-            font: {
-              transferSize: 0,
-              contentSize: 0,
-              headerSize: 0,
-              requests: 0,
-            },
-          },
+          contentTypes: {},
           assets: [],
           responseCodes: {},
           firstParty: {
             cookieStats: new Statistics(),
+            contentTypes: {},
           },
           thirdParty: {
             cookieStats: new Statistics(),
+            contentTypes: {},
           },
           domains: {},
           expireStats: new Statistics(),
@@ -113,6 +82,7 @@ module.exports = {
       // add first/third party info
       if (config.firstParty) {
         // is it a third party asset?
+
         let stats = myPage.thirdParty;
 
         if (asset.url.match(config.firstParty)) {
@@ -127,6 +97,7 @@ module.exports = {
         stats.headerSize = stats.headerSize + asset.headerSize ||
           asset.headerSize;
         stats.cookieStats.add(asset.cookies);
+        collect.contentType(asset, stats);
       }
 
       myPage.requests += 1;


### PR DESCRIPTION
@tobli / @soulgalore thoughts on adding this and possible ways to dry it up? lodash deepClone or anything in node 6 I could use that you guys are aware of?

This would allow for breakdown of  content types by 3rd party or 1st party if --firstParty regex is passed in. Use-case would be tracking specific content type optimization over time as well as possible more in-depth budgeting.