### PR TITLE
Remove fast-stats dependency and only use min/median/max values #31

### DIFF
--- a/lib/statistics.js
+++ b/lib/statistics.js
@@ -1,43 +1,33 @@
 'use strict';
 
-const Stats = require('fast-stats').Stats;
-
-function percentileName(percentile) {
-  if (percentile === 0) {
-    return 'min';
-  } else if (percentile === 100) {
-    return 'max';
-  } else if (percentile === 50) {
-    return 'median';
-  }
-  return `p${String(percentile).replace('.', '_')}`;
-}
-
 class Statistics {
   constructor() {
-    this.stats = new Stats();
+    this.values = [];
   }
 
   add(value) {
-    this.stats.push(value);
+    this.values.push(value);
     return this;
   }
 
-  summarize(options) {
-    if (isNaN(this.stats.amean())) {
+  summarize() {
+    const values = this.values;
+    // keeping backward compability
+    if (values.length === 0) {
       return undefined;
     }
 
-    options = options || {};
-    const percentiles = options.percentiles || [0, 10, 50, 90, 99, 100];
-    const decimals = options.decimals || 0;
-    const data = {};
-    const stats = this.stats;
+    values.sort((a, b) => a - b);
 
-    percentiles.forEach((p) => {
-      const name = percentileName(p);
-      data[name] = Number(stats.percentile(p).toFixed(decimals));
-    });
+    const data = {
+      min: Number(values[0]).toFixed(0),
+      max: Number(values[values.length - 1]).toFixed(0),
+    };
+
+    const middle = Math.floor(values.length / 2);
+    const isEven = values.length % 2 === 0;
+    data.median = isEven ?
+      (Number(values[middle] + values[middle - 1]) / 2).toFixed(0) : values[middle];
 
     return data;
   }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   "main": "./lib/index.js",
   "bin": "./bin/index.js",
   "dependencies": {
-    "fast-stats": "0.0.3",
     "minimist": "1.2.0"
   }
 }


### PR DESCRIPTION
We will lose p10, p90 and p99 but the code will be clean.