### PR TITLE
Tweak parsing of ”Time Since Last Modified”

### DIFF
--- a/lib/headers.js
+++ b/lib/headers.js
@@ -52,20 +52,18 @@ module.exports = {
    * @returns {int} the time since the asset was last modified in seconds.
    */
   getTimeSinceLastModified: headers => {
-    let now = new Date();
-    let lastModifiedDate;
-    if (headers['last-modified']) {
-      lastModifiedDate = new Date(headers['last-modified']);
-    } else if (headers.date) {
-      now = new Date(headers.date);
-    }
-
-    // TODO how do we define if we don't have a timing
-    // is it better to just return 0?
-    if (!lastModifiedDate) {
+    const lastModifiedHeader = headers['last-modified'];
+    if (!lastModifiedHeader) {
       return -1;
     }
 
-    return (now.getTime() - lastModifiedDate.getTime()) / 1000;
+    const lastModifiedMillis = Date.parse(lastModifiedHeader);
+
+    let createdMillis = Date.now();
+    if (headers.date) {
+      createdMillis = Date.parse(headers.date);
+    }
+
+    return (createdMillis - lastModifiedMillis) / 1000;
   }
 };

--- a/test/headersTest.js
+++ b/test/headersTest.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var assert = require('chai').assert,
-headers = require('../lib/headers')
+const assert = require('chai').assert;
+const headers = require('../lib/headers');
 
 describe('headers', function() {
 
@@ -25,6 +25,31 @@ describe('headers', function() {
 
       var flattenedHeaders = headers.flatten(harHeaders);
       assert.deepEqual(flattenedHeaders, expected);
+    });
+  });
+
+  describe('#getTimeSinceLastModified', () => {
+    it('should return -1 for missing last-modified header', () => {
+      const requestHeaders = {};
+      const timeSinceLastModified = headers.getTimeSinceLastModified(requestHeaders);
+      assert.equal(timeSinceLastModified, -1);
+    });
+
+    it('should return positive time with only last-modified header', () => {
+      const requestHeaders = {
+        'last-modified': new Date('05 October 2011 14:48 UTC').toISOString()
+      };
+      const timeSinceLastModified = headers.getTimeSinceLastModified(requestHeaders);
+      assert(timeSinceLastModified > 0);
+    });
+
+    it('should calculate diff between last-modified and date headers', () => {
+      const requestHeaders = {
+        'last-modified': new Date('05 October 2011 14:48 UTC').toISOString(),
+        'date': new Date('05 October 2011 14:49 UTC').toISOString()
+      };
+      const timeSinceLastModified = headers.getTimeSinceLastModified(requestHeaders);
+      assert.equal(timeSinceLastModified, 60);
     });
   });
 });


### PR DESCRIPTION
This is a proposed update to how we calculate time between a page was delivered (if that information exists) and when it was last modified. The PR introduces three new tests, one of them failing without the PR like this:

1) headers #getTimeSinceLastModified should calculate diff between last-modified and date headers:

AssertionError: expected 182735675.809 to equal 60
+ expected - actual

-182735675.809
+60

Parsing of date values from the headers is not changed. According to the specs, the format for the http Last-Modified and Date headers is not identical to that of javascript Date. But that’s left for a later patch.