### PR TITLE
Disable sorting of requests for WebPageTest HARs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -73,7 +73,9 @@ module.exports = {
       );
     }
 
-    har.log.entries.sort(sortByTime);
+    if (har.log.creator.name !== 'WebPagetest') {
+      har.log.entries.sort(sortByTime);
+    }
 
     har.log.entries.forEach(entry => {
       if (!testedPages[entry.pageref]) {


### PR DESCRIPTION
Sometimes run number two have earlier startedDateTime (or some
problem with our sorting?). Disabling it for now makes the
PageXray output look ok. Do we need the sorting for Browsertime?

https://github.com/sitespeedio/sitespeed.io/issues/1878