### PR TITLE
Fixing null exception with some tracking pixels

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -191,12 +191,18 @@ module.exports = {
       currentPage.headerSize += Math.max(entry.response.headersSize, 0);
 
       const entryStart = new Date(entry.startedDateTime).getTime();
-      if (pageTimings[entry.pageref] && entryStart > pageTimings[entry.pageref].onLoad) {
+      if (
+        pageTimings[entry.pageref] &&
+        entryStart > pageTimings[entry.pageref].onLoad
+      ) {
         currentPage.afterOnLoad.requests += 1;
         currentPage.afterOnLoad.transferSize += entry.response.bodySize;
         collect.contentType(asset, currentPage.afterOnLoad.contentTypes);
       }
-      if (pageTimings[entry.pageref] && entryStart > pageTimings[entry.pageref].onContentLoad) {
+      if (
+        pageTimings[entry.pageref] &&
+        entryStart > pageTimings[entry.pageref].onContentLoad
+      ) {
         currentPage.afterOnContentLoad.requests += 1;
         currentPage.afterOnContentLoad.transferSize += entry.response.bodySize;
         collect.contentType(asset, currentPage.afterOnContentLoad.contentTypes);

--- a/lib/index.js
+++ b/lib/index.js
@@ -191,12 +191,12 @@ module.exports = {
       currentPage.headerSize += Math.max(entry.response.headersSize, 0);
 
       const entryStart = new Date(entry.startedDateTime).getTime();
-      if (entryStart > pageTimings[entry.pageref].onLoad) {
+      if (pageTimings[entry.pageref] && entryStart > pageTimings[entry.pageref].onLoad) {
         currentPage.afterOnLoad.requests += 1;
         currentPage.afterOnLoad.transferSize += entry.response.bodySize;
         collect.contentType(asset, currentPage.afterOnLoad.contentTypes);
       }
-      if (entryStart > pageTimings[entry.pageref].onContentLoad) {
+      if (pageTimings[entry.pageref] && entryStart > pageTimings[entry.pageref].onContentLoad) {
         currentPage.afterOnContentLoad.requests += 1;
         currentPage.afterOnContentLoad.transferSize += entry.response.bodySize;
         collect.contentType(asset, currentPage.afterOnContentLoad.contentTypes);


### PR DESCRIPTION
This happens when the tracking pixel script is being loaded from a different domain perhaps to avoid detection.

Issue Details: https://github.com/sitespeedio/pagexray/issues/70