### PR TITLE
Entries should be independent of the order in the HAR.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -169,7 +169,10 @@ module.exports = {
 
         testedPages[entry.pageref] = currentPage;
         pages.push(currentPage);
+      } else {
+        currentPage = testedPages[entry.pageref];
       }
+
       const asset = collect.asset(entry);
       currentPage.expireStats.add(asset.expires);
       if (asset.timeSinceLastModified !== -1) {


### PR DESCRIPTION
See https://github.com/sitespeedio/sitespeed.io/issues/2409