### PR TITLE
Keep request/response headers as is and fix cookie count.

### DIFF
--- a/lib/collect.js
+++ b/lib/collect.js
@@ -43,10 +43,8 @@ module.exports = {
   asset: entry => {
     const response = entry.response;
     const request = entry.request;
-
     const contentType = util.getContentType(response.content.mimeType);
-    const requestHeaders = headers.flatten(request.headers);
-    const responseHeaders = headers.flatten(response.headers);
+    const responseHeadersFlatten = headers.flatten(response.headers);
     const content =
       response.content && response.content.text ? response.content.text : '';
     const timings = {
@@ -73,14 +71,16 @@ module.exports = {
       contentSize:
         response.content.size < 0 ? response.bodySize : response.content.size,
       headerSize: response.headersSize,
-      expires: headers.getExpires(responseHeaders),
+      expires: headers.getExpires(responseHeadersFlatten),
       status: response.status,
-      timeSinceLastModified: headers.getTimeSinceLastModified(responseHeaders),
-      cookieName: headers.getCookieName(responseHeaders),
+      timeSinceLastModified: headers.getTimeSinceLastModified(
+        responseHeadersFlatten
+      ),
+      cookieNames: headers.getCookieNames(response.headers),
       httpVersion: util.getHTTPVersion(response.httpVersion),
       headers: {
-        request: requestHeaders,
-        response: responseHeaders
+        request: request.headers,
+        response: response.headers
       },
       totalTime,
       timings,

--- a/lib/headers.js
+++ b/lib/headers.js
@@ -82,11 +82,11 @@ module.exports = {
     return (dateMillis - lastModifiedMillis) / 1000;
   },
 
-  getCookieName: headers => {
-    const cookies = headers['set-cookie'];
-    if (cookies) {
-      return cookies.split('=')[0];
-    }
-    return '';
+  getCookieNames: headers => {
+    const cookies = headers.filter(h => h.name.match(/^set-cookie$/i));
+    const cookieNames = cookies.map(h => {
+      return h.value.split('=')[0];
+    });
+    return cookieNames;
   }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -232,9 +232,9 @@ module.exports = {
           stats.headerSize + asset.headerSize || asset.headerSize;
         collect.contentType(asset, stats.contentTypes);
       }
-      if (asset.cookieName !== '') {
-        currentPage.cookieNames.push(asset.cookieName);
-        currentPage.cookies += 1;
+      if (asset.cookieNames.length > 0) {
+        currentPage.cookieNames.push(...asset.cookieNames);
+        currentPage.cookies += asset.cookieNames.length;
       }
       currentPage.requests += 1;
     });


### PR DESCRIPTION
Before we flatten the response headers, meaning if we got duplicate
header names, we lost all except one. Fixes this also fix so we
get the correct number of cookies that is set.