### PR TITLE
Fix HTTP/3, Cache-Control casing, url.parse deprecation, and empty-pageref crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG - PageXray
 
+## Unreleased
+### Fixed
+* Classify `HTTP/3` / `HTTP/3.0` connections as `h3` (previously only the lowercase `h3` / `h3-29` shorthand was recognised — the canonical form fell through to `h1`).
+* Parse `Cache-Control` directives case-insensitively (RFC 7234 §5.2). `Max-Age=42` is now read as 42 instead of 0, and `No-Cache` / `No-Store` are honoured.
+* Replace the deprecated `url.parse` (Node DEP0169) with the WHATWG `URL` parser in `getHostname`.
+* Stop throwing in `getDocumentRequests` when a page has no matching entries — return an empty array instead.
+
 ## 4.5.0 2026-05-12
 ### Added
 * Surface page-level style recalculation work on `renderBlocking.recalculateStyle`

--- a/lib/headers.js
+++ b/lib/headers.js
@@ -51,13 +51,15 @@ module.exports = {
       responseHeaders['cache-control'] &&
       responseHeaders['cache-control'].length > 0
     ) {
+      // Cache-Control directives are case-insensitive (RFC 7234 §5.2).
+      const cacheControl = responseHeaders['cache-control'][0].toLowerCase();
       if (
-        responseHeaders['cache-control'][0].indexOf('no-cache') !== -1 ||
-        responseHeaders['cache-control'][0].indexOf('no-store') !== -1
+        cacheControl.indexOf('no-cache') !== -1 ||
+        cacheControl.indexOf('no-store') !== -1
       ) {
         return 0;
       }
-      const matches = responseHeaders['cache-control'][0].match(maxAgeRegExp);
+      const matches = cacheControl.match(maxAgeRegExp);
       if (matches) {
         return parseInt(matches[1], 10);
       }

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const urlParser = require('url');
-
 // Priorities list of matchers
 const MIME_TYPE_MATCHERS = [
   [/^text\/html/, 'html'],
@@ -70,7 +68,7 @@ module.exports = {
       return 'spdy';
     } else if (version === '') {
       return 'Unknown';
-    } else if (version.startsWith('h3')) {
+    } else if (version.startsWith('h3') || version.startsWith('HTTP/3')) {
       return 'h3';
     }
     return 'h1';
@@ -84,8 +82,11 @@ module.exports = {
     if (!url) {
       return '';
     }
-
-    return urlParser.parse(url).hostname || '';
+    try {
+      return new URL(url).hostname || '';
+    } catch (e) {
+      return '';
+    }
   },
   /**
    * Get the main domain from a hostname
@@ -152,6 +153,7 @@ module.exports = {
 
     do {
       entry = pageEntries.shift();
+      if (!entry) break;
       requests.push(entry);
     } while (entry.response.redirectURL);
 

--- a/test/headersTest.js
+++ b/test/headersTest.js
@@ -124,5 +124,15 @@ describe('headers', function() {
       const expires = headers.getExpires(responseHeaders);
       assert.isTrue(expires < 0);
     });
+    it('should parse case-insensitive max-age (RFC 7234 §5.2)', () => {
+      const responseHeaders = {'cache-control': ['Max-Age=42']};
+      const expires = headers.getExpires(responseHeaders);
+      assert.equal(expires, 42);
+    });
+    it('should respect case-insensitive no-cache', () => {
+      const responseHeaders = {'cache-control': ['No-Cache, Max-Age=42']};
+      const expires = headers.getExpires(responseHeaders);
+      assert.equal(expires, 0);
+    });
   });
 });

--- a/test/utilTest.js
+++ b/test/utilTest.js
@@ -81,6 +81,24 @@ describe('util', function() {
           const result = util.getDocumentRequests(har.log.entries, firstRequest.pageref);
           assert(result.length, 1, 'Incorrectly parsed redirects');
         });
-    })
-  })
+    });
+
+    it('should return an empty array when no entries match the pageref', () => {
+      // Previously this threw "Cannot read properties of undefined (reading 'response')"
+      // when a HAR contained a page whose pageref didn't appear in log.entries.
+      const result = util.getDocumentRequests([], 'page_0');
+      assert.deepEqual(result, []);
+    });
+  });
+
+  describe('#getConnectionType', () => {
+    it('should detect HTTP/3 from the canonical string', () => {
+      // Some HARs report the version as 'HTTP/3' / 'HTTP/3.0' rather than the
+      // lowercase 'h3' shorthand. Both should map to 'h3'.
+      assert.equal(util.getConnectionType('HTTP/3'), 'h3');
+      assert.equal(util.getConnectionType('HTTP/3.0'), 'h3');
+      assert.equal(util.getConnectionType('h3'), 'h3');
+      assert.equal(util.getConnectionType('h3-29'), 'h3');
+    });
+  });
 });


### PR DESCRIPTION


  A handful of small correctness fixes that surfaced while x-raying real HARs:

  HTTP/3 traffic was being reported as plain HTTP/1 whenever the HAR carried the canonical "HTTP/3" / "HTTP/3.0" string instead of the
  lowercase "h3" shorthand — so any consumer counting h3 connections undercounted them.

  Cache-Control directives are case-insensitive per RFC 7234, but the parser only matched lowercase. A response with "Max-Age=42" was treated
  as uncacheable (returned 0), which made cache-hit reporting look worse than reality.

  Modern Node prints a DEP0169 deprecation warning every time getHostname is called because it still used the legacy url.parse. Switching to
  the WHATWG URL API silences the warning and aligns with the rest of the ecosystem.

  Finally, getDocumentRequests crashed with "Cannot read properties of undefined" when a HAR contained a page whose pageref didn't appear in
  log.entries — now it just returns an empty array.

  Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com