### PR TITLE
CLI: read HAR from stdin and print friendly errors instead of stack t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 * `defaultContentTypes` now includes `favicon` so every page has a consistent shape (matches the example in the README).
 * `xml` is now considered for `missingCompression` reporting.
 
+### Added
+* CLI can now read a HAR from stdin: `pagexray -` or piping into `pagexray` with no path argument.
+* CLI prints a friendly error to stderr and exits 1 when the file is missing or the input isn't valid JSON (previously threw a raw Node stack trace).
+
 ## 4.5.0 2026-05-12
 ### Added
 * Surface page-level style recalculation work on `renderBlocking.recalculateStyle`

--- a/bin/index.js
+++ b/bin/index.js
@@ -11,11 +11,48 @@ const argv = minimist(process.argv.slice(2), {
   boolean: ['pretty', 'includeAssets']
 });
 
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    process.stdin.on('data', chunk => chunks.push(chunk));
+    process.stdin.on('end', () =>
+      resolve(Buffer.concat(chunks).toString('utf8'))
+    );
+    process.stdin.on('error', reject);
+  });
+}
+
+function fail(message) {
+  process.stderr.write('pagexray: ' + message + '\n');
+  process.exit(1);
+}
+
+function emit(pages) {
+  if (argv.pretty) {
+    process.stdout.write(JSON.stringify(pages, null, '  ') + '\n');
+  } else {
+    process.stdout.write(JSON.stringify(pages) + '\n');
+  }
+}
+
+function run(harText, source) {
+  let har;
+  try {
+    har = JSON.parse(harText);
+  } catch (e) {
+    return fail('could not parse ' + source + ' as JSON: ' + e.message);
+  }
+  emit(pagexray.convert(har, argv));
+}
+
 if (argv.version) {
   console.log(`${packageInfo.version}`);
-} else if (argv.help || !argv._[0]) {
+} else if (argv.help || (!argv._[0] && process.stdin.isTTY)) {
   console.log('   Convert a HAR file to a (better) page summary.');
-  console.log('   Usage: pagexray [options] pathToHarFile\n');
+  console.log('   Usage: pagexray [options] pathToHarFile');
+  console.log(
+    '          pagexray [options] -                (read HAR from stdin)\n'
+  );
   console.log('   Options:');
   console.log('   --pretty              Pretty format the JSON [false]');
   console.log(
@@ -24,12 +61,21 @@ if (argv.version) {
   console.log(
     '   --firstParty          A regex defining if a URL is 1st or 3rd party URL'
   );
+} else if (!argv._[0] || argv._[0] === '-') {
+  readStdin().then(
+    text => run(text, 'stdin'),
+    err => fail('could not read stdin: ' + err.message)
+  );
 } else {
-  const har = JSON.parse(fs.readFileSync(argv._[0]));
-  const pages = pagexray.convert(har, argv);
-  if (argv.pretty) {
-    console.log(JSON.stringify(pages, null, '  '));
-  } else {
-    console.log(JSON.stringify(pages));
+  const path = argv._[0];
+  let harText;
+  try {
+    harText = fs.readFileSync(path, 'utf8');
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      return fail('file not found: ' + path);
+    }
+    return fail('could not read ' + path + ': ' + e.message);
   }
+  run(harText, path);
 }


### PR DESCRIPTION
…races

  Two small ergonomic wins for the pagexray binary.

  Folks who already have a HAR in a pipeline — generated by sitespeed.io, fetched from WPT, transformed by jq — had to round-trip it through a
   temp file before pagexray could see it. The CLI now reads from stdin when invoked as pagexray -, or when piped to with no path argument.
  The file-path form is unchanged.

  When the path was wrong, the old CLI threw a raw Node stack trace and exited with whatever fs gave back. It now prints a one-line stderr
  message ("pagexray: file not found: ...") and exits 1 — same for malformed JSON.

  Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com