### PR TITLE
Drop deprecated mocha.opts and bump engines.node to 20

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,6 @@
+{
+  "reporter": "spec",
+  "timeout": "60s",
+  "check-leaks": true,
+  "recursive": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ### Changed
 * `defaultContentTypes` now includes `favicon` so every page has a consistent shape (matches the example in the README).
 * `xml` is now considered for `missingCompression` reporting.
+* Mocha configuration moved from the deprecated `test/mocha.opts` to `.mocharc.json` so newer Mocha versions keep working.
+* `engines.node` bumped from `>=8.9.0` to `>=20.0.0`. Everything older is past Node.js EOL.
 
 ## 4.5.0 2026-05-12
 ### Added

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "dist": "npm run browserify && npm run uglify"
   },
   "engines": {
-    "node": ">=8.9.0"
+    "node": ">=20.0.0"
   },
   "devDependencies": {
     "babelify": "10.0.0",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,0 @@
---reporter spec
---timeout 60s
---check-leaks
---recursive


### PR DESCRIPTION
  Two small chores that were starting to bit-rot.

  The Mocha config still lived in test/mocha.opts, which Mocha deprecated in v6 and removed in v8 — moving the same four settings to
  .mocharc.json unblocks the eventual Mocha bump without changing how tests run today.

  engines.node was declared as >=8.9.0, which is meaningless in 2026 — every Node version older than 20 is past upstream EOL. Bumped to
  >=20.0.0 to match what consumers can actually run, and what the project already relies on (the recent switch from url.parse to the WHATWG
  URL parser needs Node 10+ anyway).

  Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com