### PR TITLE
Cookie Domain= attribute must stop at \n, not just ;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - PageXray
 
+## Unreleased
+### Fixed
+* Stop the next cookie's name leaking into a `Domain=` attribute when a HAR concatenates multiple `Set-Cookie` response headers into one value joined by `\n`. The captured domain now stops at the newline.
+
 ## 5.0.0 - 2026-05-14
 
 ### Changed

--- a/lib/headers.js
+++ b/lib/headers.js
@@ -112,8 +112,11 @@ module.exports = {
         const name = h.value.split('=')[0];
         // Cookie attribute names are case-insensitive (RFC 6265 §5.2),
         // and the Domain= attribute always follows an attribute
-        // separator (`;`), not the cookie name/value `=`.
-        const domainMatch = h.value.match(/;\s*domain=([^;]+)/i);
+        // separator (`;`), not the cookie name/value `=`. Stop at `\n`
+        // too — some HARs concatenate multiple Set-Cookie response
+        // headers into one value joined by '\n', and we don't want the
+        // next cookie's name leaking into this cookie's domain.
+        const domainMatch = h.value.match(/;\s*domain=([^;\n]+)/i);
         if (domainMatch) {
           const d = domainMatch[1].trim();
           if (!d.match(regex)) {

--- a/test/headersTest.js
+++ b/test/headersTest.js
@@ -124,3 +124,19 @@ test('getThirdPartyCookieNames: skip cookies whose domain matches first-party', 
     []
   );
 });
+
+test('getThirdPartyCookieNames: do not let a newline-joined cookie leak into the domain', t => {
+  // Some HARs concatenate two Set-Cookie headers into a single value
+  // joined by '\n'. The captured Domain= attribute must stop at the
+  // newline rather than swallowing the next cookie's name.
+  const harHeaders = [
+    {
+      name: 'Set-Cookie',
+      value: 'UID=abc; Domain=.scorecardresearch.com\nUIDR=1453756870'
+    }
+  ];
+  t.deepEqual(
+    headers.getThirdPartyCookieNames(harHeaders, '.*sitespeed.*'),
+    [{name: 'UID', domain: '.scorecardresearch.com'}]
+  );
+});


### PR DESCRIPTION
  Some HARs (older Firefox captures in particular) concatenate multiple Set-Cookie response headers into one value joined by '\n'. The
  previous capture regex for the Domain attribute ran until the next ';' — but if the next byte was a newline starting another cookie, the
  next cookie's name+value got pulled into the current cookie's domain. The aftermath was visible in pagexray output as things like Domain
  ".scorecardresearch.com\nUIDR=1453756870".

  This stops the capture at '\n' as well. The second cookie on those concatenated lines is still invisible to PageXray — surfacing it would
  mean splitting the Set-Cookie value on '\n' and treating each line as its own cookie, which is a bigger behaviour change and not in scope
  here.

  Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com